### PR TITLE
GitHub Actions: Stop reinstalling Rust on windows-11-arm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,13 +84,6 @@ jobs:
         with:
           python-version: 3.12
           architecture: arm64
-      # rust toolchain is not currently installed on windopws arm64 images https://github.com/actions/partner-runner-images/issues/77
-      - name: Setup rust
-        id: setup-rust
-        run: |
-          Invoke-WebRequest https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe -OutFile .\rustup-init.exe
-          .\rustup-init.exe -y
-          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.cargo\bin"
       - name: Build wheels
         uses: pyo3/maturin-action@v1
         with:


### PR DESCRIPTION
This issue is now resolved:
* actions/partner-runner-images#77