### PR TITLE
Add README reference in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "nh3"
 description = "Python binding to Ammonia HTML sanitizer Rust crate"
 authors = [{ name = "messense", email = "messense@icloud.com" }]
+readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 classifiers = [


### PR DESCRIPTION
On https://pypi.org/project/nh3 this will replace the message:
> __The author of this package has not provided a project description__