### PR TITLE
Validate rel attribute conflict with link_rel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use ouroboros::self_referencing;
-use pyo3::exceptions::PyTypeError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyString, PyTuple};
 
@@ -288,6 +288,19 @@ impl Cleaner {
         if let Some(callback) = attribute_filter.as_ref() {
             if !callback.bind(py).is_callable() {
                 return Err(PyTypeError::new_err("attribute_filter must be callable"));
+            }
+        }
+        if link_rel.is_some() {
+            if let Some(ref attrs) = attributes {
+                for (tag, attr_set) in attrs.iter() {
+                    if attr_set.contains("rel") {
+                        return Err(PyValueError::new_err(format!(
+                            "\"rel\" attribute is not allowed for tag \"{}\" when link_rel is set; \
+                             pass link_rel=None to manage the \"rel\" attribute directly",
+                            tag
+                        )));
+                    }
+                }
             }
         }
         let config = Config {

--- a/tests/test_nh3.py
+++ b/tests/test_nh3.py
@@ -88,6 +88,48 @@ def test_clean_with_attribute_filter():
     nh3.clean(html, attribute_filter=lambda _element, _attribute, _value: True)
 
 
+def test_clean_rel_attribute_conflict():
+    with pytest.raises(ValueError, match="link_rel is set"):
+        nh3.clean(
+            "<a href='http://example.com'>test</a>",
+            tags={"a"},
+            attributes={"a": {"href", "rel"}},
+        )
+
+    # No error when link_rel=None
+    result = nh3.clean(
+        "<a href='http://example.com' rel='nofollow'>test</a>",
+        tags={"a"},
+        attributes={"a": {"href", "rel"}},
+        link_rel=None,
+    )
+    assert result == '<a href="http://example.com" rel="nofollow">test</a>'
+
+    # No error when rel is not in attributes
+    nh3.clean(
+        "<a href='http://example.com'>test</a>",
+        tags={"a"},
+        attributes={"a": {"href"}},
+    )
+
+
+def test_cleaner_rel_attribute_conflict():
+    with pytest.raises(ValueError, match="link_rel is set"):
+        nh3.Cleaner(
+            tags={"a"},
+            attributes={"a": {"href", "rel"}},
+        )
+
+    # No error when link_rel=None
+    cleaner = nh3.Cleaner(
+        tags={"a"},
+        attributes={"a": {"href", "rel"}},
+        link_rel=None,
+    )
+    result = cleaner.clean("<a href='http://example.com' rel='nofollow'>test</a>")
+    assert result == '<a href="http://example.com" rel="nofollow">test</a>'
+
+
 def test_clean_text():
     res = nh3.clean_text('Robert"); abuse();//')
     assert res == "Robert&quot;);&#32;abuse();&#47;&#47;"


### PR DESCRIPTION
Passing `rel` in `attributes` while `link_rel` is set (the default) causes
ammonia to panic. This validates the conflict upfront and raises a `ValueError`
with a message pointing to `link_rel=None`.

Fixes #36