### PR TITLE
Expose default clean_content_tags as module constant

### DIFF
--- a/nh3.pyi
+++ b/nh3.pyi
@@ -3,6 +3,7 @@ from typing import Callable, Dict, Optional, Set
 ALLOWED_TAGS: Set[str]
 ALLOWED_ATTRIBUTES: Dict[str, Set[str]]
 ALLOWED_URL_SCHEMES: Set[str]
+CLEAN_CONTENT_TAGS: Set[str]
 
 class Cleaner:
     def __init__(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,5 +484,6 @@ fn nh3(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add("ALLOWED_TAGS", a.clone_tags())?;
     m.add("ALLOWED_ATTRIBUTES", a.clone_tag_attributes())?;
     m.add("ALLOWED_URL_SCHEMES", a.clone_url_schemes())?;
+    m.add("CLEAN_CONTENT_TAGS", a.clone_clean_content_tags())?;
     Ok(())
 }

--- a/tests/test_nh3.py
+++ b/tests/test_nh3.py
@@ -135,6 +135,12 @@ def test_clean_text():
     assert res == "Robert&quot;);&#32;abuse();&#47;&#47;"
 
 
+def test_clean_content_tags_constant():
+    assert isinstance(nh3.CLEAN_CONTENT_TAGS, set)
+    assert "script" in nh3.CLEAN_CONTENT_TAGS
+    assert "style" in nh3.CLEAN_CONTENT_TAGS
+
+
 def test_is_html():
     assert not nh3.is_html("plain text")
     assert nh3.is_html("<p>html!</p>")


### PR DESCRIPTION
Ammonia already exposes `clone_clean_content_tags()` on the builder, but nh3 didn't surface it as a Python-accessible constant. I needed to check the defaults while working with `clean_content_tags` and noticed this was missing.

Adds `CLEAN_CONTENT_TAGS` following the same pattern as `ALLOWED_TAGS`, `ALLOWED_ATTRIBUTES`, and `ALLOWED_URL_SCHEMES`.

Closes #116