### PR TITLE
Accept frozenset and Mapping in type stubs

### DIFF
--- a/nh3.pyi
+++ b/nh3.pyi
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional, Set
+from typing import AbstractSet, Callable, Dict, Mapping, Optional, Set
 
 ALLOWED_TAGS: Set[str]
 ALLOWED_ATTRIBUTES: Dict[str, Set[str]]
@@ -8,35 +8,35 @@ CLEAN_CONTENT_TAGS: Set[str]
 class Cleaner:
     def __init__(
         self,
-        tags: Optional[Set[str]] = None,
-        clean_content_tags: Optional[Set[str]] = None,
-        attributes: Optional[Dict[str, Set[str]]] = None,
+        tags: Optional[AbstractSet[str]] = None,
+        clean_content_tags: Optional[AbstractSet[str]] = None,
+        attributes: Optional[Mapping[str, AbstractSet[str]]] = None,
         attribute_filter: Optional[Callable[[str, str, str], Optional[str]]] = None,
         strip_comments: bool = True,
         link_rel: Optional[str] = "noopener noreferrer",
-        generic_attribute_prefixes: Optional[Set[str]] = None,
-        tag_attribute_values: Optional[Dict[str, Dict[str, Set[str]]]] = None,
-        set_tag_attribute_values: Optional[Dict[str, Dict[str, str]]] = None,
-        url_schemes: Optional[Set[str]] = None,
-        allowed_classes: Optional[Dict[str, Set[str]]] = None,
-        filter_style_properties: Optional[Set[str]] = None,
+        generic_attribute_prefixes: Optional[AbstractSet[str]] = None,
+        tag_attribute_values: Optional[Mapping[str, Mapping[str, AbstractSet[str]]]] = None,
+        set_tag_attribute_values: Optional[Mapping[str, Mapping[str, str]]] = None,
+        url_schemes: Optional[AbstractSet[str]] = None,
+        allowed_classes: Optional[Mapping[str, AbstractSet[str]]] = None,
+        filter_style_properties: Optional[AbstractSet[str]] = None,
     ) -> None: ...
     def clean(self, html: str) -> str: ...
 
 def clean(
     html: str,
-    tags: Optional[Set[str]] = None,
-    clean_content_tags: Optional[Set[str]] = None,
-    attributes: Optional[Dict[str, Set[str]]] = None,
+    tags: Optional[AbstractSet[str]] = None,
+    clean_content_tags: Optional[AbstractSet[str]] = None,
+    attributes: Optional[Mapping[str, AbstractSet[str]]] = None,
     attribute_filter: Optional[Callable[[str, str, str], Optional[str]]] = None,
     strip_comments: bool = True,
     link_rel: Optional[str] = "noopener noreferrer",
-    generic_attribute_prefixes: Optional[Set[str]] = None,
-    tag_attribute_values: Optional[Dict[str, Dict[str, Set[str]]]] = None,
-    set_tag_attribute_values: Optional[Dict[str, Dict[str, str]]] = None,
-    url_schemes: Optional[Set[str]] = None,
-    allowed_classes: Optional[Dict[str, Set[str]]] = None,
-    filter_style_properties: Optional[Set[str]] = None,
+    generic_attribute_prefixes: Optional[AbstractSet[str]] = None,
+    tag_attribute_values: Optional[Mapping[str, Mapping[str, AbstractSet[str]]]] = None,
+    set_tag_attribute_values: Optional[Mapping[str, Mapping[str, str]]] = None,
+    url_schemes: Optional[AbstractSet[str]] = None,
+    allowed_classes: Optional[Mapping[str, AbstractSet[str]]] = None,
+    filter_style_properties: Optional[AbstractSet[str]] = None,
 ) -> str: ...
 def clean_text(html: str) -> str: ...
 def is_html(html: str) -> bool: ...

--- a/tests/test_nh3.py
+++ b/tests/test_nh3.py
@@ -141,6 +141,23 @@ def test_clean_content_tags_constant():
     assert "style" in nh3.CLEAN_CONTENT_TAGS
 
 
+def test_frozenset_args():
+    html = "<b><img src='x'>hello</b>"
+    assert nh3.clean(html, tags=frozenset({"b"})) == "<b>hello</b>"
+    assert (
+        nh3.clean(html, tags=frozenset({"img"}), attributes={"img": frozenset({"src"})})
+        == '<img src="x">hello'
+    )
+
+
+def test_cleaner_frozenset_args():
+    cleaner = nh3.Cleaner(
+        tags=frozenset({"b", "img"}),
+        attributes={"img": frozenset({"src"})},
+    )
+    assert cleaner.clean("<b><img src='x'>hi</b>") == '<b><img src="x">hi</b>'
+
+
 def test_is_html():
     assert not nh3.is_html("plain text")
     assert nh3.is_html("<p>html!</p>")


### PR DESCRIPTION
PyO3 has supported extracting `HashSet` from both `set` and `frozenset` since
0.22, but the type stubs only declared `Set[str]` for set parameters and `Dict`
for mapping parameters. This meant type checkers like pyright would reject
perfectly valid calls like `nh3.clean(html, tags=frozenset({"b"}))`.

I switched the parameter types to `AbstractSet` and `Mapping` — this correctly
reflects what PyO3 accepts at runtime. Constants like `ALLOWED_TAGS` stay typed
as `Set[str]` since they are concrete sets returned by ammonia.

Also added a couple of tests to verify frozenset works at runtime.

Closes #29