### PR TITLE
Add doctest coverage for module docstrings and RST files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install nh3 --no-index --find-links dist --force-reinstall
           pip install pytest
-          cd tests && pytest
+          pytest
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
@@ -66,7 +66,7 @@ jobs:
         run: |
           pip install nh3 --no-index --find-links dist --force-reinstall
           pip install pytest
-          cd tests && pytest
+          pytest
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
@@ -98,7 +98,7 @@ jobs:
         run: |
           pip install nh3 --no-index --find-links dist --force-reinstall
           pip install pytest
-          cd tests && pytest
+          pytest
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
@@ -139,7 +139,7 @@ jobs:
         run: |
           pip install nh3 --no-index --find-links dist --force-reinstall
           pip install pytest
-          cd tests && pytest
+          pytest
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
@@ -197,7 +197,7 @@ jobs:
             pip3 install -U pip pytest
           run: |
             pip3 install nh3 --no-index --find-links dist/ --force-reinstall
-            cd tests && pytest
+            pytest
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
@@ -240,7 +240,7 @@ jobs:
             source .venv/bin/activate
             pip install -U pip pytest
             pip install nh3 --no-index --find-links /io/dist/ --force-reinstall
-            cd tests && python3 -m pytest
+            python3 -m pytest
           '
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -289,7 +289,7 @@ jobs:
             source .venv/bin/activate
             pip install pytest
             pip install nh3 --no-index --find-links dist/ --force-reinstall
-            cd tests && python3 -m pytest
+            python3 -m pytest
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,7 @@ dynamic = ["urls", "version"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+
+[tool.pytest.ini_options]
+addopts = "--doctest-glob=*.rst"
+testpaths = ["tests", "docs"]

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,17 @@
+import doctest
+
+import nh3
+
+
+def test_docstrings():
+    finder = doctest.DocTestFinder()
+    runner = doctest.DocTestRunner(verbose=False)
+    globs = {"nh3": nh3}
+    for name in ["clean", "clean_text", "is_html"]:
+        obj = getattr(nh3, name)
+        for test in finder.find(obj, f"nh3.{name}"):
+            if test.examples:
+                test.globs.update(globs)
+                runner.run(test)
+    results = runner.summarize(verbose=False)
+    assert results.failed == 0, f"{results.failed} doctest(s) failed"


### PR DESCRIPTION
I tried `--doctest-modules` but it turns out `DocTestFinder` can't recurse into
compiled PyO3 modules, so the examples in the Rust doc-comments were never
exercised. I added a small test file that feeds them to the stdlib `doctest`
runner directly.

I also pointed pytest at `docs/` via `testpaths` and `--doctest-glob` so the
`>>>` blocks in `index.rst` get picked up too, and updated CI to run from the
repo root instead of `cd tests`.

Closes #73