### PR TITLE
Validate clean_content_tags conflict with tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ struct Inner {
 /// :param tags: Sets the tags that are allowed.
 /// :type tags: ``set[str]``, optional
 /// :param clean_content_tags: Sets the tags whose contents will be completely removed from the output.
+///     Must be disjoint from ``tags`` (or the default allowed set when ``tags``
+///     is omitted); a tag cannot be both kept and have its content stripped.
 /// :type clean_content_tags: ``set[str]``, optional
 /// :param attributes: Sets the HTML attributes that are allowed on specific tags,
 ///    ``*`` key means the attributes are allowed on any tag.
@@ -312,6 +314,30 @@ impl Cleaner {
                         )));
                     }
                 }
+            }
+        }
+        if let Some(ref clean_tags) = clean_content_tags {
+            // A tag listed in both the allowed `tags` set and `clean_content_tags`
+            // makes ammonia panic. Raise an explicit ValueError instead. When the
+            // caller omits `tags`, ammonia falls back to its default allowed set,
+            // so check against that default in order to catch e.g.
+            // `clean_content_tags={"p"}`.
+            let conflict = match tags.as_ref() {
+                Some(allowed) => clean_tags.iter().find(|t| allowed.contains(t.as_str())),
+                None => {
+                    let default_tags = ammonia::Builder::default().clone_tags();
+                    clean_tags
+                        .iter()
+                        .find(|t| default_tags.contains(t.as_str()))
+                }
+            };
+            if let Some(tag) = conflict {
+                return Err(PyValueError::new_err(format!(
+                    "tag \"{}\" cannot appear in both `tags` and `clean_content_tags`; \
+                     either remove it from `clean_content_tags` or pass an explicit \
+                     `tags` set that excludes it",
+                    tag
+                )));
             }
         }
         let config = Config {

--- a/tests/test_nh3.py
+++ b/tests/test_nh3.py
@@ -130,6 +130,50 @@ def test_cleaner_rel_attribute_conflict():
     assert result == '<a href="http://example.com" rel="nofollow">test</a>'
 
 
+def test_clean_content_tags_overlap_with_default_tags():
+    # Without explicit ``tags``, ammonia's default allowed tags are used; placing
+    # any of those tags in ``clean_content_tags`` would otherwise panic the
+    # interpreter. Validate up-front with a clear ValueError instead.
+    with pytest.raises(ValueError, match="clean_content_tags"):
+        nh3.clean("<p>hi</p>", clean_content_tags={"p"})
+
+    with pytest.raises(ValueError, match="clean_content_tags"):
+        nh3.clean("<div><b>hi</b></div>", clean_content_tags={"b", "script"})
+
+
+def test_clean_content_tags_overlap_with_explicit_tags():
+    # Explicit ``tags`` set that intersects ``clean_content_tags`` is also a
+    # contradiction and must raise rather than panic.
+    with pytest.raises(ValueError, match="clean_content_tags"):
+        nh3.clean(
+            "<div><b>hi</b></div>",
+            tags={"div", "b"},
+            clean_content_tags={"b"},
+        )
+
+
+def test_clean_content_tags_no_overlap_ok():
+    # ``clean_content_tags`` works with tags absent from the allowed set
+    # (default or explicit).
+    assert nh3.clean("<script>x</script>safe", clean_content_tags={"script"}) == "safe"
+    assert (
+        nh3.clean(
+            "<div><b>hi</b></div>",
+            tags={"div"},
+            clean_content_tags={"b"},
+        )
+        == "<div></div>"
+    )
+
+
+def test_cleaner_clean_content_tags_overlap():
+    with pytest.raises(ValueError, match="clean_content_tags"):
+        nh3.Cleaner(clean_content_tags={"p"})
+
+    with pytest.raises(ValueError, match="clean_content_tags"):
+        nh3.Cleaner(tags={"a"}, clean_content_tags={"a"})
+
+
 def test_clean_text():
     res = nh3.clean_text('Robert"); abuse();//')
     assert res == "Robert&quot;);&#32;abuse();&#47;&#47;"


### PR DESCRIPTION
Passing a tag in `clean_content_tags` that is also in the allowed `tags` set
(either explicit or ammonia's default) causes an assertion panic in ammonia
that surfaces as an unrecoverable `PanicException` in Python. This validates
the conflict upfront and raises a `ValueError` naming the conflicting tag,
mirroring the existing `link_rel`/`rel` validation pattern.

Fixes #24