### PR TITLE
Don’t depend on deprecated pyo3/generate-import-lib feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ammonia = "4.1.2"
-pyo3 = { version = "0.29.0", features = ["abi3-py38", "generate-import-lib"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py38"] }
 ouroboros = "0.18"


### PR DESCRIPTION
Since PyO3 0.29, the `generate-import-lib` feature is deprecated and no longer has any effect; it is present only for backward-compatibility. See https://github.com/PyO3/pyo3/pull/5866.